### PR TITLE
Feature/rubocop fixes

### DIFF
--- a/sensu-plugins-ansible.gemspec
+++ b/sensu-plugins-ansible.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 require 'date'

--- a/sensu-plugins-ansible.gemspec
+++ b/sensu-plugins-ansible.gemspec
@@ -41,6 +41,6 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_development_dependency 'rake',                      '~> 12.0'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
   s.add_development_dependency 'rspec',                     '~> 3.4'
-  s.add_development_dependency 'rubocop',                   '~> 0.51.0'
+  s.add_development_dependency 'rubocop',                   '~> 0.57.2'
   s.add_development_dependency 'yard',                      '~> 0.8'
 end


### PR DESCRIPTION
Supersedes https://github.com/sensu-plugins/sensu-plugins-ansible/pull/9 w/ the fixup due to the new Rubocop version. 